### PR TITLE
Fixes from #innovation_day 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 
 /public/assets
 .byebug_history
+.tool-versions
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '2.5.1'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '~> 6.0.0'
+gem 'rails', '~> 6.0.2'
 
 # Use Puma as the app server
 gem 'puma', '~> 3.11'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -358,7 +358,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   pg
   puma (~> 3.11)
-  rails (~> 6.0.0)
+  rails (~> 6.0.2)
   redis-rails
   sass-rails (~> 5)
   selenium-webdriver

--- a/app/middleware/unfreezer.rb
+++ b/app/middleware/unfreezer.rb
@@ -1,0 +1,10 @@
+class Unfreezer
+  def initialize app
+    @app = app
+  end
+
+  def call env
+    raw_status, raw_headers, raw_body = @app.call(env)
+    [raw_status.dup, raw_headers.dup, raw_body.dup]
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,11 +19,14 @@ require 'rails/test_unit/railtie'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module Shipit
+require_relative '../app/middleware/unfreezer'
+
+module ShipitPoc
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    config.middleware.use Unfreezer
     config.active_job.queue_adapter = :sidekiq
     config.cache_store = :redis_cache_store, { url: ENV['REDIS_URL'] }
     config.active_record.cache_versioning = false

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,7 @@ module Shipit
     config.cache_store = :redis_cache_store, { url: ENV['REDIS_URL'] }
     config.active_record.cache_versioning = false
 
+    Pubsubstub.use_persistent_connections = false
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/initializers/monkey_patch.rb
+++ b/config/initializers/monkey_patch.rb
@@ -1,9 +1,0 @@
-module Shipit
-  class Hook < ActiveRecord::Base
-    CONTENT_TYPES = {
-      'json' => 'application/json',
-      'form' => 'application/x-www-form-urlencoded',
-    }
-  end
-end
-

--- a/config/initializers/monkey_patch.rb
+++ b/config/initializers/monkey_patch.rb
@@ -1,6 +1,9 @@
 module Shipit
-  def user_access_tokens_key
-    ENV['SECRET_KEY_BASE'].byteslice(0, 32)
-    # (secrets.user_access_tokens_key.presence || secrets.secret_key_base).byteslice(0, 32)
+  class Hook < ActiveRecord::Base
+    CONTENT_TYPES = {
+      'json' => 'application/json',
+      'form' => 'application/x-www-form-urlencoded',
+    }
   end
 end
+


### PR DESCRIPTION
## Notes: ##
1. The Rails version bump isn't strictly necessary, it was something I tried, but I figure it's a minor fix bump so not worth the effort to remove from here.
2. `.tool-versions` is added to .gitignore because I'm using local config for asdf to run this repo's ruby version.
3. The `Bump after buildpack` was another test, but it has no actual changes and is just an empty commit I used to bump a deploy on heroku.

The real hero here is the `Unfreezer` middleware (and possibly the `Shipit` => `ShipitPoc` name change, our application module should not be named the same as a module defined by a gem...not certain this caused any problems directly but it was part of the configuration I got working on heroku.